### PR TITLE
Removed code to work around build error

### DIFF
--- a/kvm-rvmi-kmod/external-module-compat-comm.h
+++ b/kvm-rvmi-kmod/external-module-compat-comm.h
@@ -1740,10 +1740,6 @@ static inline void __cpumask_clear_cpu(int cpu, struct cpumask *dstp)
 #define wait_queue_entry_t wait_queue_t
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0) && LINUX_VERSION_CODE > KERNEL_VERSION(4,4,0)
-#define CPUID_7_ECX 16
-#endif
-
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,3,0)
 #define X86_FEATURE_SHA_NI	( 9*32+29)
 #endif


### PR DESCRIPTION
Removed code for building in Linux_kernel_version between 4.6 and 4.4
Or else it will conflict with rvmi/kvm-rvmi-kmod/x86/external-module-compat.h:
enum cpuid_leafs
{
CPUID_1_EDX = 0,
CPUID_8000_0001_EDX,
CPUID_8086_0001_EDX,
CPUID_LNX_1,
CPUID_1_ECX,
CPUID_C000_0001_EDX,
CPUID_8000_0001_ECX,
CPUID_LNX_2,
CPUID_LNX_3,
CPUID_7_0_EBX,
CPUID_D_1_EAX,
CPUID_F_0_EDX,
CPUID_F_1_EDX,
CPUID_8000_0008_EBX,
CPUID_6_EAX,
CPUID_8000_000A_EDX,
CPUID_7_ECX,
};

compiler will say: ERROR: expected identifier before numeric constant ...